### PR TITLE
Feature/upload

### DIFF
--- a/packages/core/upload/admin/src/hooks/useUpload.js
+++ b/packages/core/upload/admin/src/hooks/useUpload.js
@@ -11,7 +11,7 @@ import { getTrad } from '../utils';
 const endpoint = `/${pluginId}`;
 
 const uploadAsset = (asset, folderId, cancelToken, onProgress, post) => {
-  const { rawFile, caption, name, alternativeText } = asset;
+  const { rawFile, caption, name, alternativeText, collectionName,  collectionField } = asset;
   const formData = new FormData();
 
   formData.append('files', rawFile);
@@ -23,6 +23,8 @@ const uploadAsset = (asset, folderId, cancelToken, onProgress, post) => {
       caption,
       alternativeText,
       folder: folderId,
+      collectionName,
+      collectionField
     })
   );
 

--- a/packages/core/upload/server/content-types/file/schema.js
+++ b/packages/core/upload/server/content-types/file/schema.js
@@ -101,6 +101,14 @@ module.exports = {
       private: true,
       searchable: false,
     },
+    collectionName: {
+      type: 'string',
+      configurable: false,
+    },
+    collectionField: {
+      type: 'string',
+      configurable: false,
+    },
   },
   // experimental feature:
   indexes: [
@@ -136,3 +144,4 @@ module.exports = {
     },
   ],
 };
+


### PR DESCRIPTION
Feature details:

We have seen that when a content specialist logs into the Media Library and tries to upload content, there is little flexibility around validation of those files. Feature to include extra metadata, like selecting category of the uploaded media that points to a specific collection, would help content specialist to use it a reference to validate media items when referencing it to a collection item.

We changed the schema of upload model to include to extra fields: collectionName and collectionField. So that content specialists can include these two fields while uploading.

Also we changed the UI of the upload modal, so that we can select the collectionName and collectionField when uploading the media.